### PR TITLE
implement Diffusion Map for custom kernel and for precomputed Gram matrix

### DIFF
--- a/src/ManifoldLearning.jl
+++ b/src/ManifoldLearning.jl
@@ -3,9 +3,9 @@ module ManifoldLearning
     import Base: show, summary
     import SparseArrays: AbstractSparseArray, SparseMatrixCSC, spzeros, spdiagm, findnz
     import Statistics: mean, std
-    import StatsBase: StatsBase, fit, standardize
+    import StatsBase: StatsBase, fit, standardize, pairwise
     import MultivariateStats: outdim, projection,  KernelPCA, transform, transform!,
-                              principalvars, dmat2gram, gram2dmat, pairwise
+                              principalvars, dmat2gram, gram2dmat
     import LinearAlgebra: eigvals, mul!, svd, qr, Symmetric, eigen, eigen!, tr, rmul!, I, norm, Diagonal, issymmetric
     import LightGraphs: neighbors, nv, add_edge!, connected_components, vertices,
                         dijkstra_shortest_paths, induced_subgraph, weights

--- a/src/ManifoldLearning.jl
+++ b/src/ManifoldLearning.jl
@@ -6,7 +6,7 @@ module ManifoldLearning
     import StatsBase: StatsBase, fit, standardize
     import MultivariateStats: outdim, projection,  KernelPCA, transform, transform!,
                               principalvars, dmat2gram, gram2dmat, pairwise
-    import LinearAlgebra: eigvals, mul!, svd, qr, Symmetric, eigen, eigen!, tr, rmul!, I, norm, Diagonal
+    import LinearAlgebra: eigvals, mul!, svd, qr, Symmetric, eigen, eigen!, tr, rmul!, I, norm, Diagonal, issymmetric
     import LightGraphs: neighbors, nv, add_edge!, connected_components, vertices,
                         dijkstra_shortest_paths, induced_subgraph, weights
     import SimpleWeightedGraphs: SimpleWeightedGraph

--- a/src/diffmaps.jl
+++ b/src/diffmaps.jl
@@ -86,7 +86,7 @@ function fit(::Type{DiffMap}, X::AbstractMatrix{T};
             ) where {T<:Real}
     if isa(kernel, Function)
         # compute Gram matrix
-        L = StatsBase.pairwise(kernel, eachcol(X), symmetric=true)
+        L = pairwise(kernel, eachcol(X), symmetric=true)
     else
         # X is the pre-computed Gram matrix
         L = deepcopy(X) # deep copy needed b/c of procedure for α > 0

--- a/src/diffmaps.jl
+++ b/src/diffmaps.jl
@@ -50,7 +50,7 @@ Fit a isometric mapping model to `data`.
   if `isnothing(kernel)`, `data` is instead the (n_observations, n_observations) precomputed Gram matrix.
 
 # Keyword arguments
-* `kernel::Union{Nothing, Function}=(x, y) -> exp(-(x .- y) .^ 2 / ɛ)`: the kernel function. 
+* `kernel::Union{Nothing, Function}=(x, y) -> exp(-sum((x .- y) .^ 2) / ɛ)`: the kernel function. 
  maps two input vectors (observations) to a scalar (a metric of their similarity).
  by default, a Gaussian kernel. if `isnothing(kernel)`, we assume `data` is instead 
  the (n_observations, n_observations) precomputed Gram matrix.

--- a/src/diffmaps.jl
+++ b/src/diffmaps.jl
@@ -50,7 +50,7 @@ Fit a isometric mapping model to `data`.
   if `isnothing(kernel)`, `data` is instead the (n_observations, n_observations) precomputed Gram matrix.
 
 # Keyword arguments
-* `kernel::Union{Nothing, Function}=(x, y) -> exp((x .- y) .^ 2 / ϵ)`: the kernel function. 
+* `kernel::Union{Nothing, Function}=(x, y) -> exp(-(x .- y) .^ 2 / ϵ)`: the kernel function. 
  maps two input vectors (observations) to a scalar (a metric of their similarity).
  by default, a Gaussian kernel. if `isnothing(kernel)`, we assume `data` is instead 
  the (n_observations, n_observations) precomputed Gram matrix.

--- a/src/diffmaps.jl
+++ b/src/diffmaps.jl
@@ -50,7 +50,7 @@ Fit a isometric mapping model to `data`.
   if `isnothing(kernel)`, `data` is instead the (n_observations, n_observations) precomputed Gram matrix.
 
 # Keyword arguments
-* `kernel::Union{Nothing, Function}=(x, y) -> exp(-(x .- y) .^ 2 / ϵ)`: the kernel function. 
+* `kernel::Union{Nothing, Function}=(x, y) -> exp(-(x .- y) .^ 2 / ɛ)`: the kernel function. 
  maps two input vectors (observations) to a scalar (a metric of their similarity).
  by default, a Gaussian kernel. if `isnothing(kernel)`, we assume `data` is instead 
  the (n_observations, n_observations) precomputed Gram matrix.

--- a/src/diffmaps.jl
+++ b/src/diffmaps.jl
@@ -46,25 +46,52 @@ end
 Fit a isometric mapping model to `data`.
 
 # Arguments
-* `data`: a matrix of observations. Each column of `data` is an observation.
+* `data::Matrix`: a (n_features, n_observations) matrix of observations. Each column of `data` is an observation.
+  if `isnothing(kernel)`, `data` is instead the (n_observations, n_observations) precomputed Gram matrix.
 
 # Keyword arguments
-* `maxoutdim`: a dimension of the reduced space.
-* `t`: a number of transitions
-* `α`: a normalization parameter
-* `ɛ`: a Gaussian kernel variance (the scale parameter)
+* `kernel::Union{Nothing, Function}=(x, y) -> exp((x .- y) .^ 2 / ϵ)`: the kernel function. 
+ maps two input vectors (observations) to a scalar (a metric of their similarity).
+ by default, a Gaussian kernel. if `isnothing(kernel)`, we assume `data` is instead 
+ the (n_observations, n_observations) precomputed Gram matrix.
+* `ɛ::Real=1.0`: the Gaussian kernel variance (the scale parameter). ignored if custom `kernel` passed.
+* `maxoutdim::Int=2`: the dimension of the reduced space.
+* `t::Int=1`: the number of transitions
+* `α::Real=0.0`: a normalization parameter
 
 # Examples
 ```julia
-M = fit(DiffMap, rand(3,100)) # construct diffusion map model
-R = transform(M)              # perform dimensionality reduction
+X = rand(3, 100)     # toy data matrix, 100 observations
+
+# default kernel
+M = fit(DiffMap, X)  # construct diffusion map model
+R = transform(M)     # perform dimensionality reduction
+
+# custom kernel
+kernel = (x, y) -> x' * y # linear kernel
+M = fit(DiffMap, X, kernel=kernel)
+
+# precomputed Gram matrix
+kernel = (x, y) -> x' * y # linear kernel
+K = StatsBase.pairwise(kernel, eachcol(X), symmetric=true) # custom Gram matrix
+M = fit(DiffMap, K, kernel=nothing)
 ```
 """
-function fit(::Type{DiffMap}, X::AbstractMatrix{T}; maxoutdim::Int=2, t::Int=1, α::Real=0.0, ɛ::Real=1.0) where {T<:Real}
-    # compute kernel matrix
-    sumX = sum(X.^ 2, dims=1)
-    L = exp.(-( transpose(sumX) .+ sumX .- 2*transpose(X) * X ) ./ convert(T, ɛ))
-    # L = pairwise((x,y)-> exp(-norm(x-y,2)^2/ε), Xtr)
+function fit(::Type{DiffMap}, X::AbstractMatrix{T};
+             ɛ::Real=1.0,
+             kernel::Union{Nothing, Function}=(x, y) -> exp(-sum((x .- y) .^ 2) / ɛ), 
+             maxoutdim::Int=2, 
+             t::Int=1, 
+             α::Real=0.0
+            ) where {T<:Real}
+    if isa(kernel, Function)
+        # compute Gram matrix
+        L = StatsBase.pairwise(kernel, eachcol(X), symmetric=true)
+    else
+        # X is the pre-computed Gram matrix
+        L = deepcopy(X) # deep copy needed b/c of procedure for α > 0
+        @assert issymmetric(L)
+    end
 
     # Calculate Laplacian & normalize it
     if α > 0
@@ -72,7 +99,7 @@ function fit(::Type{DiffMap}, X::AbstractMatrix{T}; maxoutdim::Int=2, t::Int=1, 
         L ./= (D * transpose(D)) .^ convert(T, α)
     end
     D = Diagonal(vec(sum(L, dims=1)))
-    M = inv(D)*L
+    M = inv(D) * L # normalize rows to interpret as transition probabilities
 
     # D = Diagonal(vec(sum(L, dims=1)))
     # D⁻ᵅ = inv(D^α)
@@ -82,11 +109,12 @@ function fit(::Type{DiffMap}, X::AbstractMatrix{T}; maxoutdim::Int=2, t::Int=1, 
 
     # Eigendecomposition & reduction
     F = eigen(M, permute=false, scale=false)
-    λ = real.(F.values)
+    # for symmetric matrix, eigenvalues should be real but owing to numerical imprecision, could have nonzero-imaginary parts.
+    λ = real.(F.values) 
     idx = sortperm(λ, rev=true)[2:maxoutdim+1]
     λ = λ[idx]
-    V = real.(F.vectors[:,idx])
-    Y = (λ.^t) .* V'
+    V = real.(F.vectors[:, idx])
+    Y = (λ .^ t) .* V'
 
     return DiffMap{T}(t, α, ɛ, λ, L, Y)
 end

--- a/src/diffmaps.jl
+++ b/src/diffmaps.jl
@@ -79,7 +79,7 @@ M = fit(DiffMap, K, kernel=nothing)
 """
 function fit(::Type{DiffMap}, X::AbstractMatrix{T};
              ɛ::Real=1.0,
-             kernel::Union{Nothing, Function}=(x, y) -> exp(-sum((x .- y) .^ 2) / ɛ), 
+             kernel::Union{Nothing, Function}=(x, y) -> exp(-sum((x .- y) .^ 2) / convert(T, ɛ)), 
              maxoutdim::Int=2, 
              t::Int=1, 
              α::Real=0.0

--- a/src/nearestneighbors.jl
+++ b/src/nearestneighbors.jl
@@ -29,7 +29,7 @@ function knn(NN::BruteForce{T}, X::AbstractVecOrMat{T}; self=false) where T<:Rea
     k = NN.k
     @assert n > k "Number of observations must be more then $(k)"
 
-    D = pairwise((x,y)->norm(x-y), NN.fitted, X)
+    D = pairwise((x,y)->norm(x-y), eachcol(NN.fitted), eachcol(X))
 
     d = Array{T}(undef, k, n)
     e = Array{Int}(undef, k, n)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,7 +74,7 @@ end
                     end
                 end
                 Y_custom_K = fit(algorithm, custom_K; kwargs..., kernel=nothing)
-                @test isapprox(Y_custom_K.proj, Y.proj)
+                @test Y_custom_K.proj ≈ Y.proj
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,9 +61,23 @@ end
                 @test neighbors(Y) == k
                 @test length(vertices(Y)) > 1
             end
+            
+            # test if we provide pre-computed Gram matrix
+            if algorithm == DiffMap && T == Float64
+                kernel = (x, y) -> exp(-sum((x .- y) .^ 2) / 1.0) # default kernel
+                n_obs = size(X)[2]
+                custom_K = zeros(n_obs, n_obs)
+                for i = 1:n_obs
+                    for j = i:n_obs
+                        custom_K[i, j] = kernel(X[:, i], X[:, j])
+                        custom_K[j, i] = custom_K[i, j]
+                    end
+                end
+                Y_custom_K = fit(algorithm, custom_K; kwargs..., kernel=nothing)
+                @test isapprox(Y_custom_K.proj, Y.proj)
+            end
         end
     end
-
 end
 
 @testset "OOS" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using ManifoldLearning
 import ManifoldLearning: BruteForce, knn, swiss_roll
+import StatsBase: pairwise
 using Test
 import Random
 
@@ -39,7 +40,8 @@ end
     X, L = swiss_roll()
 
     # test algorithms
-    @testset for algorithm in [Isomap, LEM, LLE, HLLE, LTSA, DiffMap]
+    #@testset for algorithm in [Isomap, LEM, LLE, HLLE, LTSA, DiffMap]
+    @testset for algorithm in [DiffMap]
         for (k, T) in zip([5, 12], [Float32, Float64])
             # construct KW parameters
             kwargs = [:maxoutdim=>d]
@@ -63,13 +65,14 @@ end
             end
             
             # test if we provide pre-computed Gram matrix
-            if algorithm == DiffMap && T == Float64
-                kernel = (x, y) -> exp(-sum((x .- y) .^ 2) / 1.0) # default kernel
+            if algorithm == DiffMap
+                kernel = (x, y) -> exp(-sum((x .- y) .^ 2)) # default kernel
                 n_obs = size(X)[2]
-                custom_K = zeros(n_obs, n_obs)
+                #custom_K = pairwise(kernel, eachcol(X), symmetric=true)
+                custom_K = zeros(T, n_obs, n_obs)
                 for i = 1:n_obs
                     for j = i:n_obs
-                        custom_K[i, j] = kernel(X[:, i], X[:, j])
+                        custom_K[i, j] = kernel(convert(Array{T}, X[:, i]), convert(Array{T}, X[:, j]))
                         custom_K[j, i] = custom_K[i, j]
                     end
                 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using ManifoldLearning
 import ManifoldLearning: BruteForce, knn, swiss_roll
-import StatsBase: pairwise
 using Test
 import Random
 
@@ -68,7 +67,6 @@ end
             if algorithm == DiffMap
                 kernel = (x, y) -> exp(-sum((x .- y) .^ 2)) # default kernel
                 n_obs = size(X)[2]
-                #custom_K = pairwise(kernel, eachcol(X), symmetric=true)
                 custom_K = zeros(T, n_obs, n_obs)
                 for i = 1:n_obs
                     for j = i:n_obs


### PR DESCRIPTION
now the diffusion map works for a custom kernel and for a pre-computed Gram matrix.

the only awkward thing is that the \epsilon is not used if a custom kernel is passed. I noted that in the doc string so should be clear how it works.

I added a test to make sure this gives the same result as the default kernel when the Gram matrix is precomputed.
oddly, the non-diffusion-map tests did not run for me owing to `LightGraphs` errors. looks like the github action is not set up to run the tests?

let me know if you have any changes in here you wish me to make. the `pairwise` had to come from `StatsBase`.

```julia
algorithm = HLLE: Error During Test at /Users/cokes/.julia/dev/ManifoldLearning/test/runtests.jl:42
  Got exception outside of a @test
  MethodError: no method matching connected_components(::SimpleWeightedGraphs.SimpleWeightedGraph{Int64, Float32})
  Closest candidates are:
    connected_components(::LightGraphs.AbstractGraph{T}) where T at ~/.julia/packages/LightGraphs/IgJif/src/connectivity.jl:100
  Stacktrace:
    [1] largest_component(G::SimpleWeightedGraphs.SimpleWeightedGraph{Int64, Float32})
      @ ManifoldLearning ~/.julia/dev/ManifoldLearning/src/utils.jl:52
    [2] fit(::Type{HLLE}, X::Matrix{Float32}; k::Int64, maxoutdim::Int64, nntype::Type)
      @ ManifoldLearning ~/.julia/dev/ManifoldLearning/src/hlle.jl:54
    [3] macro expansion
      @ ~/.julia/dev/ManifoldLearning/test/runtests.jl:53 [inlined]
    [4] macro expansion
      @ ~/julia/usr/share/julia/stdlib/v1.8/Test/src/Test.jl:1432 [inlined]
    [5] macro expansion
      @ ~/.julia/dev/ManifoldLearning/test/runtests.jl:42 [inlined]
    [6] macro expansion
      @ ~/julia/usr/share/julia/stdlib/v1.8/Test/src/Test.jl:1356 [inlined]
    [7] top-level scope
      @ ~/.julia/dev/ManifoldLearning/test/runtests.jl:37
    [8] include(mod::Module, _path::String)
      @ Base ./Base.jl:421
    [9] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:306
   [10] _start()
      @ Base ./client.jl:509
```